### PR TITLE
fix(picker): properly handle smartcase highlighting in preview and list

### DIFF
--- a/lua/snacks/picker/core/list.lua
+++ b/lua/snacks/picker/core/list.lua
@@ -586,7 +586,12 @@ function M:render()
     end
     local search = Snacks.picker.util.parse(vim.trim(self.picker.input.filter.search))
     if self.matcher_regex.pattern ~= search then
-      self.matcher_regex:init(search)
+      self.matcher_regex:init(
+        Snacks.picker.util.prepare_highlight_pattern(
+          search,
+          { case_insensitive_regex_option = true, remove_grep_flags = true }
+        )
+      )
     end
 
     self.visible = {}

--- a/lua/snacks/picker/core/preview.lua
+++ b/lua/snacks/picker/core/preview.lua
@@ -323,7 +323,12 @@ function M:loc()
         hl_group = "SnacksPickerSearch",
       })
     elseif self.filter and vim.trim(self.filter.search) ~= "" then
-      local ok, re = pcall(vim.regex, vim.trim(self.filter.search))
+      -- regardless of the matcher options, match caseinsensitive
+      local cleaned_pattern = Snacks.picker.util.prepare_highlight_pattern(
+        self.filter.search,
+        { trim = "both", case_insensitive_regex_option = true, remove_grep_flags = true }
+      )
+      local ok, re = pcall(vim.regex, cleaned_pattern)
       if ok and re then
         local start = self.item.pos[2]
         local from, to ---@type number?, number?

--- a/lua/snacks/picker/util/init.lua
+++ b/lua/snacks/picker/util/init.lua
@@ -620,4 +620,41 @@ function M.globber(globs)
   end
 end
 
+---@alias snacks.picker.util.trim_mode "both"|"left"|"right"|"none"
+
+--- Prepare pattern for highlighting by removing grep flags and applying trim options
+---@param pattern string The input pattern
+---@param opts? {trim?: snacks.picker.util.trim_mode, case_insensitive_regex_option?: boolean, remove_grep_flags?: boolean} Options for trimming, case sensitivity, and grep flag removal
+---@return string cleaned_pattern The cleaned pattern ready for highlighting
+function M.prepare_highlight_pattern(pattern, opts)
+  opts = opts or {}
+  local trim_mode = opts.trim or "none"
+  local case_insensitive = opts.case_insensitive_regex_option == true -- default to false
+  local remove_grep_flags = opts.remove_grep_flags == true -- default to false
+
+  local cleaned = pattern
+
+  -- Remove grep flags like (?i), (?-i), (?m), etc. if requested
+  if remove_grep_flags then
+    cleaned = cleaned:gsub("%(%?[%-]?[imsx]*%)", "")
+  end
+
+  -- Apply trimming based on mode
+  if trim_mode == "both" then
+    cleaned = vim.trim(cleaned)
+  elseif trim_mode == "left" then
+    cleaned = cleaned:gsub("^%s*", "")
+  elseif trim_mode == "right" then
+    cleaned = cleaned:gsub("%s*$", "")
+  elseif trim_mode == "none" then
+    -- No trimming
+  end
+
+  -- Add \c for case-insensitive matching for vim.regex if requested
+  if case_insensitive and not cleaned:find("\\[Cc]") then
+    cleaned = "\\c" .. cleaned
+  end
+  return cleaned
+end
+
 return M


### PR DESCRIPTION
## Summary
Fixes issue #2043 - smartcase highlighting inconsistency between picker list and preview.

## Problem
When using smartcase search with mixed-case patterns, the preview highlighting was inconsistent with the list highlighting:
- List used `filter.pattern` (smartcase processed)
- Preview used `filter.search` (original pattern) 
- This caused highlighting to fail when smartcase converted patterns to case-insensitive

## Solution
1. **Added utility function** `prepare_highlight_pattern()` in `picker/util/init.lua`:
   - Removes grep flags like `(?i)`, `(?-i)` etc.
   - Supports flexible trimming options (`left`, `right`, `both`, `none`)
   - Optional case-insensitive regex flag (`\c`) insertion

2. **Updated preview.lua** to use the new utility for consistent case-insensitive highlighting

3. **Updated list.lua** to use the utility for regex matcher initialization

## Test plan
- [x] Test smartcase with mixed-case search patterns
- [x] Verify consistent highlighting between list and preview
- [x] Test with various grep flags in search patterns  
- [x] Test trimming functionality

🤖 Generated with [Claude Code](https://claude.ai/code)